### PR TITLE
Bugfix in single-pole CDF for core shells + target name reading

### DIFF
--- a/INPUT_CDF/Al2O3_no_CDF.cdf
+++ b/INPUT_CDF/Al2O3_no_CDF.cdf
@@ -1,0 +1,5 @@
+Aluminium oxide	! material name
+2		! how many elements are in this molecule of solid
+13	2	! atomic number, contribution of 1st element into compount 
+8	3	! atomic number, contribution of 2d element into compount 
+3.99	6510.0	4.4	8.8e0	! density [g/cm^3], speed of sound [m/s], fermi level [eV], bandgap [eV]

--- a/INPUT_CDF/CdS_sp.cdf
+++ b/INPUT_CDF/CdS_sp.cdf
@@ -1,0 +1,3 @@
+CdS						! Material name
+CdS						! Chemical formula
+4.82	1750.0	1.26	2.16	! density [g/cm^3], speed of sound [m/s], fermi energy [eV], band gap [eV]

--- a/INPUT_CDF/CdTe_sp.cdf
+++ b/INPUT_CDF/CdTe_sp.cdf
@@ -1,0 +1,3 @@
+CdTe						! Material name
+CdTe						! Chemical formula
+5.86	2000.0	0.7378	1.44	! density [g/cm^3], speed of sound [m/s], fermi energy [eV], band gap [eV]

--- a/INPUT_CDF/CeO2.cdf
+++ b/INPUT_CDF/CeO2.cdf
@@ -1,0 +1,25 @@
+CeO2
+2		! how many elements are in this molecule of solid
+58	1	! atomic number, contribution of 2d element into compound 
+8	2	! atomic number, contribution of 3d element into compound 
+7.22	4005.0	1.5	! density [g/cm^3], speed of sound [m/s], fermi level [eV]
+5		! number of shells of the first element: Ce
+1	1	40000.0e0	2	0.551e0	! number of CDF functions, shell-designator, ionization potential, number of electrons, Auger-time
+40000	95	40000	! E0, A, Gamma coefficients
+1	2	5600.0e0	8	0.337e0	! number of CDF functions, shell-designator, ionization potential, number of electrons, Auger-time
+5600	375	5700	! E0, A, Gamma coefficients
+1	7	870.0e0	20	1.006e0		! number of CDF functions, shell-designator, ionization potential, number of electrons, Auger-time
+950	875	455 ! E0, A, Gamma coefficients
+1	15	100	24	6.47e0
+124	920	35
+5	63	3.0e0	16	1.0e23	! number of CDF functions, shell-designator, ionization potential, number of electrons, Auger-time
+3.2	-1.7	5
+4.5	1.6	3
+14.3	30	2.5
+28	300	30
+32	230	7
+1		! number of shells of the second element: O
+1	1	545.0	2	3.98e0	! number of CDF functions, shell-designator, ionization potential, number of electrons, Auger-time
+540	216	240	! E0, A, Gamma coefficients
+1		! phonon peaks:
+0.075	1.50E-03	3.00E-03

--- a/INPUT_CDF/ITO_sp.cdf
+++ b/INPUT_CDF/ITO_sp.cdf
@@ -1,0 +1,6 @@
+ITO						! Material name
+3		! how many elements are in this molecule of solid
+49	1.3647	! atomic number, contribution of 1st element into compound 
+50	0.6353	! atomic number, contribution of 2d element into compound 
+8	3	! atomic number, contribution of 3d element into compound 
+4.82	1750.0	0.34	4.09	! density [g/cm^3], speed of sound [m/s], fermi energy [eV], band gap [eV]

--- a/INPUT_CDF/PbS_sp.cdf
+++ b/INPUT_CDF/PbS_sp.cdf
@@ -1,0 +1,3 @@
+PbS						! Material name
+PbS						! Chemical formula
+7.60	2040.0	0.1759	0.37	! density [g/cm^3], speed of sound [m/s], fermi energy [eV], band gap [eV]

--- a/Source_files/Cross_sections.f90
+++ b/Source_files/Cross_sections.f90
@@ -590,7 +590,9 @@ subroutine get_single_pole(Target_atoms, NumPar, CDF_Phonon, Matter, Error_messa
                contrib = Target_atoms(i)%Pers/N_at_mol  ! contribution of the atoms into the compound
 
                ! Set them according to the single-pole approximation:
-               Omega = w_plasma(1d6*Matter%At_dens*NVB*contrib) ! function below, plasma frequency^2 [1/s]^2
+               !Omega = w_plasma(1d6*Matter%At_dens * Target_atoms(j)%Pers/N_at_mol) ! plasma frequency^2 [1/s]^2; module "Cross_sections"
+               !Omega = w_plasma(1d6*Matter%At_dens*NVB*contrib) ! function below, plasma frequency^2 [1/s]^2
+               Omega = w_plasma(1d6*Matter%At_dens*NVB) ! function below, plasma frequency^2 [1/s]^2
 
                Target_atoms(i)%Ritchi(j)%E0(1) = Target_atoms(i)%Ip(j)+10.0d0   ! [eV] -- approximation
 
@@ -598,8 +600,8 @@ subroutine get_single_pole(Target_atoms, NumPar, CDF_Phonon, Matter, Error_messa
                Target_atoms(i)%Ritchi(j)%Gamma(1) = Target_atoms(i)%Ritchi(j)%E0(1)
                ! A is set vie normalization (sum rule):
                Target_atoms(i)%Ritchi(j)%A(1) = 1.0d0   ! just to get sum rule to renormalize below
-               ! Get sum rule:
-               Omega = w_plasma(1d6*Matter%At_dens)   ! below
+               ! Get sum rule (per molecule):
+               Omega = w_plasma(1d6*Matter%At_dens * contrib)   ! below
                call sumrules(Target_atoms(i)%Ritchi(j)%A, Target_atoms(i)%Ritchi(j)%E0, Target_atoms(i)%Ritchi(j)%Gamma, &
                               ksum, fsum, Target_atoms(i)%Ip(j), Omega) ! below
 

--- a/Source_files/Reading_files_and_parameters.f90
+++ b/Source_files/Reading_files_and_parameters.f90
@@ -614,8 +614,8 @@ subroutine reading_material_parameters(Material_file, Short_material_file, Targe
    logical, intent(inout) :: read_well  ! did we read the file well?
    
    real(8) M
-   integer FN2, Reason, i, j, k, l, N, Shl, CDF_coef, Shl_num
-   character(100) Error_descript, temp
+   integer FN2, Reason, i, j, k, l, N, Shl, CDF_coef, Shl_num, comment_start
+   character(100) Error_descript, temp, read_line
    character(3) Name
    character(11) Shell_name
    character(30) Full_Name
@@ -644,7 +644,33 @@ subroutine reading_material_parameters(Material_file, Short_material_file, Targe
    endif
    
    i = 0
-   READ(FN2,*,IOSTAT=Reason) Matter%Target_name ! first line is the full material name
+   !READ(FN2,*,IOSTAT=Reason) Matter%Target_name ! first line is the full material name
+   Matter%Target_name = '' ! to start with
+   read_line = '' ! to start with
+   READ(FN2,'(a)',IOSTAT=Reason) read_line   ! read the full line
+   comment_start = index(read_line, '!')  ! to exclude comment, if any
+   ! Save the name into the variable:
+   if (comment_start > 1) then   ! trim comment
+      Matter%Target_name = read_line(1:comment_start-1)
+   else  ! no comment
+      Matter%Target_name = trim(adjustl(read_line))
+   endif
+   ! Also, remove TABs if any:
+   comment_start = index(read_line, CHAR(9))  ! to exclude TABs, if any
+   if (comment_start > 1) then   ! trim comment
+      Matter%Target_name = read_line(1:comment_start-1)
+   elseif (comment_start == 1) then   ! omit leading TAB
+      Matter%Target_name = read_line(2:)
+   else  ! no comment
+      Matter%Target_name = trim(adjustl(read_line))
+   endif
+   Matter%Target_name = trim(adjustl(Matter%Target_name))
+
+!    print*, LEN(trim(adjustl(Matter%Target_name))), trim(adjustl(Matter%Target_name))
+!    print*, '::'//Matter%Target_name//'::'
+!    pause 'Matter%Target_name'
+
+
    Matter%Chem = ''  ! to start with
    
    READ(FN2,*,IOSTAT=Reason) N   ! number of elements in this compound
@@ -1141,14 +1167,34 @@ subroutine read_short_scdf(FN2, Target_atoms, NumPar, CDF_Phonon, Matter, Error_
    type(Error_handling), intent(inout) :: Error_message  ! save data about error if any
    logical, intent(inout) :: read_well  ! did we read the file well?
    real(8) M
-   integer Reason, i, j, k, l, N, Shl, CDF_coef, Shl_num
-   character(100) Error_descript
+   integer Reason, i, j, k, l, N, Shl, CDF_coef, Shl_num, comment_start
+   character(100) Error_descript, read_line
    character(3) Name
    character(11) Shell_name
    character(30) Full_Name
 
    i = 0
-   READ(FN2,*,IOSTAT=Reason) Matter%Target_name ! first line is the full material name
+   !READ(FN2,*,IOSTAT=Reason) Matter%Target_name ! first line is the full material name
+   READ(FN2,'(a)',IOSTAT=Reason) read_line   ! read the full line
+   comment_start = index(read_line, '!')  ! to exclude comment, if any
+   ! Save the name into the variable:
+   if (comment_start > 1) then   ! trim comment
+      Matter%Target_name = read_line(1:comment_start-1)
+   else  ! no comment
+      Matter%Target_name = trim(adjustl(read_line))
+   endif
+    ! Also, remove TABs if any:
+   comment_start = index(read_line, CHAR(9))  ! to exclude TABs, if any
+   if (comment_start > 1) then   ! trim comment
+      Matter%Target_name = read_line(1:comment_start-1)
+   elseif (comment_start == 1) then   ! omit leading TAB
+      Matter%Target_name = read_line(2:)
+   else  ! no comment
+      Matter%Target_name = trim(adjustl(read_line))
+   endif
+   Matter%Target_name = trim(adjustl(Matter%Target_name))
+
+
    READ(FN2,*,IOSTAT=Reason) N   ! number of elements in this compound
    call read_file(Reason, i, read_well) ! reports if everything read well
    if (.not. read_well) goto 2014


### PR DESCRIPTION
- Core shells sp_CDF fitting renormalized per molecule for consistency
- Target material name from CDF-file reading corrected to allow for names made of several words
- Some test materials CDF added